### PR TITLE
fix: expire flows individually, rather than all at once

### DIFF
--- a/pkg/collector/server.go
+++ b/pkg/collector/server.go
@@ -16,7 +16,8 @@ package collector
 
 import (
 	"fmt"
-	"github.com/cloudflare/goflow/v3/pb"
+
+	flowprotob "github.com/cloudflare/goflow/v3/pb"
 	"github.com/cloudflare/goflow/v3/utils"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,7 +49,7 @@ func (c *col) Describe(descs chan<- *prometheus.Desc) {
 	c.totalFlowsCounter.Describe(descs)
 	c.scrapingSum.Describe(descs)
 	for _, m := range c.metrics {
-		m.counter.Describe(descs)
+		m.Describe(descs)
 	}
 }
 
@@ -62,7 +63,7 @@ func (c *col) Collect(ch chan<- prometheus.Metric) {
 	c.droppedFlowsCounter.Collect(ch)
 	c.totalFlowsCounter.Collect(ch)
 	for _, m := range c.metrics {
-		m.counter.Collect(ch)
+		m.Collect(ch)
 	}
 }
 

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -15,17 +15,18 @@
 package collector
 
 import (
+	"os"
+
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rkosegi/ipfix-collector/pkg/public"
 	"gopkg.in/yaml.v3"
-	"os"
-	"time"
 )
 
 type metricEntry struct {
 	counter *prometheus.CounterVec
 	labels  []*labelProcessor
-	cleaner *time.Ticker
+	metrics *ttlcache.Cache[string, prometheus.Counter]
 }
 
 type FilterFn func(flow *public.Flow) bool


### PR DESCRIPTION
Wow, thanks for merging the other PR so quickly. Here is the other one I was prepping (and that's my last for this weekend!).

This change keeps the same metric for a given set of labels until it is unused for `flush_interval` settings. This means that an ongoing flow will keep increasing the byte count, rather than being zeroed out again each time `flush_interval` deletes all metrics.

This may make it easier to get better graphs out of ongoing usage.

Thanks again for a nice tool.