### PR TITLE
fix: create new Counter rather than mutate CounterVec

### DIFF
--- a/pkg/collector/metric_test.go
+++ b/pkg/collector/metric_test.go
@@ -15,10 +15,14 @@
 package collector
 
 import (
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/rkosegi/ipfix-collector/pkg/public"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMetrics(t *testing.T) {
@@ -40,8 +44,74 @@ func TestMetrics(t *testing.T) {
 	f.AddAttr("source_ip", []byte{10, 11, 12, 13})
 	f.AddAttr("bytes", uint64(30))
 	m.apply(f)
-	v := &dto.Metric{}
-	assert.NoError(t, m.counter.WithLabelValues("10.11.12.13").Write(v))
-	assert.Equal(t, float64(30), v.Counter.GetValue())
 
+	assert.Equal(t, float64(30), getMetric(t, m, "10.11.12.13"))
+}
+
+// This test is a bit awful because it has time.Sleep() in it and takes approx 2 seconds
+// This is to verify that metrics expire as expected
+func TestMetricExpiration(t *testing.T) {
+	s := &public.MetricSpec{
+		Name:        "test1",
+		Description: "Test metric 1",
+		Labels: []public.MetricLabel{
+			{
+				Name:      "source",
+				Value:     "source_ip",
+				OnMissing: "empty_str",
+				Converter: "ipv4",
+			},
+		},
+	}
+	m := &metricEntry{}
+	m.init("netflow", s, 1)
+	f := &public.Flow{}
+	f.AddAttr("source_ip", []byte{10, 11, 12, 13})
+	f.AddAttr("bytes", uint64(1))
+
+	// start tests
+
+	// t = 0.0 - add a thing, verify we get the stat back
+	assert.Equal(t, 0, countMetrics(m))
+	m.apply(f)
+	assert.Equal(t, 1, countMetrics(m))
+	assert.Equal(t, true, metricExists(m, "10.11.12.13"))
+	assert.Equal(t, float64(1), getMetric(t, m, "10.11.12.13"))
+	time.Sleep(time.Millisecond * 500)
+
+	// t = 0.5 - first thing should still be validate as we have 1 sec TTL, now add second thing
+	m.apply(f)
+	assert.Equal(t, 1, countMetrics(m))
+	assert.Equal(t, true, metricExists(m, "10.11.12.13"))
+	assert.Equal(t, float64(2), getMetric(t, m, "10.11.12.13"))
+	time.Sleep(time.Millisecond * 600)
+
+	// t = 1.1 - adding second thing should have extended TTL, so verify we still have both things
+	assert.Equal(t, true, metricExists(m, "10.11.12.13"))
+	assert.Equal(t, float64(2), getMetric(t, m, "10.11.12.13"))
+	time.Sleep(time.Millisecond * 500)
+
+	// t = 1.6 - now it should have expired, verify it has gone
+	assert.Equal(t, 0, countMetrics(m))
+	assert.Equal(t, false, metricExists(m, "10.11.12.13"))
+
+	// t = 1.6 - add it again, verifiy counter has reset
+	m.apply(f)
+	assert.Equal(t, 1, countMetrics(m))
+	assert.Equal(t, true, metricExists(m, "10.11.12.13"))
+	assert.Equal(t, float64(1), getMetric(t, m, "10.11.12.13"))
+}
+
+func metricExists(m *metricEntry, v string) bool {
+	return m.metrics.Get(v, ttlcache.WithDisableTouchOnHit[string, prometheus.Counter]()) != nil
+}
+
+func getMetric(t *testing.T, m *metricEntry, v string) float64 {
+	vv := dto.Metric{}
+	assert.NoError(t, (m.metrics.Get(v, ttlcache.WithDisableTouchOnHit[string, prometheus.Counter]()).Value()).Write(&vv))
+	return *vv.Counter.Value
+}
+
+func countMetrics(m *metricEntry) int {
+	return m.metrics.Len()
 }

--- a/pkg/collector/types.go
+++ b/pkg/collector/types.go
@@ -25,6 +25,7 @@ import (
 
 type metricEntry struct {
 	counter *prometheus.CounterVec
+	opts    prometheus.CounterOpts
 	labels  []*labelProcessor
 	metrics *ttlcache.Cache[string, prometheus.Counter]
 }
@@ -38,6 +39,7 @@ type FlowMatcher struct {
 
 type labelProcessor struct {
 	attr        string
+	name        string
 	applyFn     func(flow *public.Flow) string
 	onMissingFn func(flow *public.Flow) string
 	converterFn func(interface{}) string


### PR DESCRIPTION
I made a bit of a mistake yesterday when changing the cleanup. While it should have correctly cleared the metrics that we export, I forgot that CounterVec keeps its own map of Counter (which wouldn't have expired). Sorry about that!

This change fixes that so that we create the Counters separately. Now the CounterVec is only used for generating the `Desc()`. This also adds a test to verify behaviour, although it's a bit awful as it relies on time passing for expiration, so let's see if it's flaky or not.

Previously we used the CounterVec to create the Counter, which has the side-effect of leaving that Counter in the map inside of CounterVec, which in addition to leaking memory will also mean that we will inadvertently re-use a counter that is not 0 after it was meant to expire.