### PR TITLE
fix: occasional 500 error when being scraped for metrics

### DIFF
--- a/pkg/collector/metric.go
+++ b/pkg/collector/metric.go
@@ -49,10 +49,12 @@ func (m *metricEntry) init(prefix string, spec *public.MetricSpec, flushInterval
 }
 
 func (m *metricEntry) Collect(ch chan<- prometheus.Metric) {
-	m.metrics.Range(func(item *ttlcache.Item[string, prometheus.Counter]) bool {
+	// we don't use the Range function on the cache as it doesn't seem to be
+	// very thread-safe, ie it emits the same value more than once which
+	// results in 500 errors when being scraped. So instead we take a copy...
+	for _, item := range m.metrics.Items() {
 		ch <- item.Value()
-		return true
-	})
+	}
 }
 
 func (m *metricEntry) Describe(ch chan<- *prometheus.Desc) {


### PR DESCRIPTION
We are seeing errors on the /metrics end-point suggesting that the same metric is attempted to being exported more than once during the same collect.

I suspect this is because the ttlcache.Range() function doesn't grab a mutex for the entire loop, and that the cleanup or other modication is causing the same values to be emitted more than once during the same iteration.

This change gets a copy of the map then iterates over that, and hopefully stops that error condition from manifesting itself.

(We'll keep an eye on for a while to see if this re-occurs, but wanted to open the PR early in case the previous change is breaking anyone else)