### PR TITLE
Add some additional configuration options for DNS lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /config.yaml
 coverage.out
 .idea
+netflow-collector
+netflow-collector.exe


### PR DESCRIPTION
Great exporter - made it quite simple to start seeing flows on my network!

This PR enables a capability similar in spirit to the dashboard shown on the README. It allows for configuring DNS lookups differently between remote and local hosts as well as makes the IP address usable as the DNS name in the case a reverse lookup fails. This enables me to create a dashboard that shows overall packets per second in and out per host on the network (and with DHCP leases including reverse DNS records, it is much more clear what host is active).

Note: Although three new options have been added, all are configured by default to match the current behavior of the exporter to avoid surprises for users.