### PR TITLE
feat: build for additional architecture aarch64

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/aarch64
           build-args: |
             GIT_COMMIT=${{ github.sha }}
             VERSION=${{ github.ref_name }}


### PR DESCRIPTION
I run netflow-collector on a raspberry-pi which needs the binary to be compiled for the linux/aarch64 architecture