### PR TITLE
Potential fix for code scanning alert no. 12: Incorrect conversion between integer types

### DIFF
--- a/pkg/collector/filter.go
+++ b/pkg/collector/filter.go
@@ -68,13 +68,13 @@ func getIsFilterFn(rule *public.FlowMatchRule) (FilterFn, error) {
 }
 
 func getIsUint32FilterFn(rule *public.FlowMatchRule) (FilterFn, error) {
-	i, err := strconv.Atoi(*rule.IsUint32)
+	parsed, err := strconv.ParseUint(*rule.IsUint32, 10, 32)
 	if err != nil {
 		return nil, err
 	}
 	return func(flow *public.Flow) bool {
 		v := flow.AsUint32(rule.Match)
-		return v != nil && *v == uint32(i)
+		return v != nil && *v == uint32(parsed)
 	}, nil
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/rkosegi/netflow-collector/security/code-scanning/12](https://github.com/rkosegi/netflow-collector/security/code-scanning/12)

The best fix is to parse directly as an unsigned 32-bit integer instead of parsing as architecture-sized `int` and then narrowing. In `pkg/collector/filter.go`, inside `getIsUint32FilterFn`, replace `strconv.Atoi` with `strconv.ParseUint(..., 10, 32)`, then convert the parsed result once to `uint32` after successful parse. Use that precomputed `uint32` in the closure for comparison.

This preserves existing functionality (parse decimal numeric string, return parse error on invalid input) while removing truncation/wrap risk and satisfying CodeQL’s recommendation. No new imports are required because `strconv` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
